### PR TITLE
fix Attachment.Field Value name

### DIFF
--- a/roboslack-api/src/main/java/com/palantir/roboslack/api/attachments/components/Field.java
+++ b/roboslack-api/src/main/java/com/palantir/roboslack/api/attachments/components/Field.java
@@ -34,7 +34,7 @@ import org.immutables.value.Value;
 public abstract class Field {
 
     private static final String TITLE_FIELD = "title";
-    private static final String VALUE_FIELD = "text";
+    private static final String VALUE_FIELD = "value";
     private static final String SHORT_FIELD = "short";
 
     public static Builder builder() {

--- a/roboslack-api/src/test/resources/parameters/attachments/attachment1.json
+++ b/roboslack-api/src/test/resources/parameters/attachments/attachment1.json
@@ -2,12 +2,12 @@
   "fields": [
     {
       "title": "Field1Title",
-      "text": "Field1Text",
+      "value": "Field1Text",
       "short": true
     },
     {
       "title": "Field2Title",
-      "text": "Field2Text",
+      "value": "Field2Text",
       "short": true
     }
   ],

--- a/roboslack-api/src/test/resources/parameters/attachments/components/fields/field1.json
+++ b/roboslack-api/src/test/resources/parameters/attachments/components/fields/field1.json
@@ -1,5 +1,5 @@
 {
   "title": "Something",
-  "text": "Some text",
+  "value": "Some text",
   "short": true
 }


### PR DESCRIPTION
This is a small bugfix for Roboslack's mapping of the `Field` `Attachment`'s Value property. Roboslack is currently passing the JSON field name `text` when it should be passing `value` instead.

Documentation here: https://api.slack.com/docs/message-attachments

Before:

<img width="556" alt="before_fields" src="https://user-images.githubusercontent.com/1137427/27672869-8a49d6b8-5c52-11e7-8071-b87ef8a1aa97.png">

After:

<img width="550" alt="after_fields" src="https://user-images.githubusercontent.com/1137427/27672873-8f77a89a-5c52-11e7-8249-367a191a7dc7.png">


@dotCipher for PR.
