### PR TITLE
changing defaults for parsemode, unfurllinks, unfurlmedia

### DIFF
--- a/roboslack-api/src/main/java/com/palantir/roboslack/api/MessageRequest.java
+++ b/roboslack-api/src/main/java/com/palantir/roboslack/api/MessageRequest.java
@@ -90,7 +90,7 @@ public abstract class MessageRequest {
     @Value.Default
     @JsonProperty(UNFURL_MEDIA_FIELD)
     public boolean unfurlMedia() {
-        return true;
+        return false;
     }
 
     /**
@@ -101,7 +101,7 @@ public abstract class MessageRequest {
     @Value.Default
     @JsonProperty(UNFURL_LINKS_FIELD)
     public boolean unfurlLinks() {
-        return true;
+        return false;
     }
 
     /**
@@ -126,7 +126,7 @@ public abstract class MessageRequest {
      */
     @Value.Default
     public ParseMode parse() {
-        return ParseMode.FULL;
+        return ParseMode.NONE;
     }
 
     /**


### PR DESCRIPTION
We should revisit our default settings for `ParseMode`, `UnfurlLinks`, and `UnfurlMedia`. Since RoboSlack specifies all Slack Markdown for a Slack message, we should not need Slack to perform any additional parsing on messages coming from the library.

* See https://api.slack.com/docs/message-formatting#parsing_modes for more details on parsing modes.
* See https://api.slack.com/docs/message-link-unfurling for more details on unfurling links and media.

The current defaults mean:
* `ParseMode=FULL` - anything that looks like a URL to Slack will be processed with additional Markdown. This breaks Roboslack's `LinkDecorator`'s `<link|text>` Markdown, as Slack will change this to something like `<<link>|text>` when parsing the message on `FULL` mode. We end up seeing this in Slack:

<img width="567" alt="screen shot 2017-06-30 at 2 13 39 am" src="https://user-images.githubusercontent.com/1137427/27729256-01ca1f44-5d3a-11e7-87ae-8ef3e1d22c6d.png">


* `unfurl_links=true` and `unfurl_media=true` - this expands any URLs/images in a Slack message to show link/image previews. In my opinion, this behavior should be set to `false` unless explicitly asked for otherwise, as it ends up generating link/image previews unintentionally:

<img width="523" alt="screen shot 2017-06-30 at 2 14 01 am" src="https://user-images.githubusercontent.com/1137427/27729280-200f6784-5d3a-11e7-850b-17521c8c8953.png">
