### PR TITLE
Asynchronous sending + junit5 bump

### DIFF
--- a/extras/jackson-support/build.gradle
+++ b/extras/jackson-support/build.gradle
@@ -16,13 +16,11 @@
 
 apply from: "${rootDir}/gradle/java.gradle"
 apply from: "${rootDir}/gradle/junit.gradle"
-apply from: "${rootDir}/gradle/immutables.gradle"
-apply from: "${rootDir}/gradle/publish.gradle"
 
 dependencies {
-    compile project(":extras:jackson-support")
-    compile "com.google.guava:guava:${guavaVersion}"
-
-    testCompile "org.hamcrest:hamcrest-all:${hamcrestVersion}"
-    testCompile "org.mockito:mockito-core:${mockitoVersion}"
+    compile "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    compile "com.fasterxml.jackson.module:jackson-module-afterburner:${jacksonVersion}"
+    compile "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${jacksonVersion}"
+    compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jacksonVersion}"
+    compile "com.fasterxml.jackson.datatype:jackson-datatype-guava:${jacksonVersion}"
 }

--- a/extras/jackson-support/src/main/java/com/palantir/roboslack/jackson/ObjectMappers.java
+++ b/extras/jackson-support/src/main/java/com/palantir/roboslack/jackson/ObjectMappers.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.roboslack.api.testing;
+package com.palantir.roboslack.jackson;
 
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -27,11 +27,9 @@ import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 
 public final class ObjectMappers {
 
-    public static final ObjectMapper DEFAULT = newObjectMapper();
-
     private ObjectMappers() {}
 
-    private static ObjectMapper newObjectMapper() {
+    public static ObjectMapper newObjectMapper() {
         return new ObjectMapper().registerModule(new GuavaModule())
                 .registerModule(new Jdk8Module().configureAbsentsAsNulls(true))
                 .registerModule(new AfterburnerModule())

--- a/extras/slack-clients/build.gradle
+++ b/extras/slack-clients/build.gradle
@@ -16,13 +16,10 @@
 
 apply from: "${rootDir}/gradle/java.gradle"
 apply from: "${rootDir}/gradle/junit.gradle"
-apply from: "${rootDir}/gradle/immutables.gradle"
-apply from: "${rootDir}/gradle/publish.gradle"
 
 dependencies {
     compile project(":extras:jackson-support")
     compile "com.google.guava:guava:${guavaVersion}"
-
-    testCompile "org.hamcrest:hamcrest-all:${hamcrestVersion}"
-    testCompile "org.mockito:mockito-core:${mockitoVersion}"
+    compile "com.squareup.retrofit2:retrofit:${retrofitVersion}"
+    compile "com.squareup.retrofit2:converter-jackson:${retrofitVersion}"
 }

--- a/extras/slack-clients/src/main/java/com/palantir/roboslack/clients/SlackClients.java
+++ b/extras/slack-clients/src/main/java/com/palantir/roboslack/clients/SlackClients.java
@@ -27,12 +27,16 @@ import retrofit2.converter.jackson.JacksonConverterFactory;
 
 /**
  * Utility class for generating service clients for RPC calls to Slack (intended for internal use only).
+ *
+ * @since 1.0.0
  */
 public final class SlackClients {
 
+    private static final String DEFAULT_USER_AGENT = "RoboSlack/1.0.0";
+
     private SlackClients() {}
 
-    private static String trailingSlash(String uri) {
+    private static String addTrailingSlash(String uri) {
         return uri.charAt(uri.length() - 1) == '/' ? uri : uri + "/";
     }
 
@@ -46,11 +50,15 @@ public final class SlackClients {
     public static <T> T create(Class<T> clazz, String userAgent, String uri,
             Converter.Factory... specialPurposeConverters) {
         Retrofit.Builder retrofit = new Retrofit.Builder()
-                .baseUrl(trailingSlash(uri))
+                .baseUrl(addTrailingSlash(uri))
                 .client(createOkHttpClient(userAgent));
         Stream.of(specialPurposeConverters).forEach(retrofit::addConverterFactory);
         retrofit.addConverterFactory(JacksonConverterFactory.create(ObjectMappers.newObjectMapper()));
         return retrofit.build().create(clazz);
+    }
+
+    public static <T> T create(Class<T> clazz, String uri, Converter.Factory... specialPurposeConverters) {
+        return create(clazz, DEFAULT_USER_AGENT, uri, specialPurposeConverters);
     }
 
 }

--- a/extras/slack-clients/src/main/java/com/palantir/roboslack/clients/SlackClients.java
+++ b/extras/slack-clients/src/main/java/com/palantir/roboslack/clients/SlackClients.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.roboslack.clients;
+
+import com.palantir.roboslack.jackson.ObjectMappers;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import okhttp3.ConnectionPool;
+import okhttp3.OkHttpClient;
+import retrofit2.Converter;
+import retrofit2.Retrofit;
+import retrofit2.converter.jackson.JacksonConverterFactory;
+
+/**
+ * Utility class for generating service clients for RPC calls to Slack (intended for internal use only).
+ */
+public final class SlackClients {
+
+    private SlackClients() {}
+
+    private static String trailingSlash(String uri) {
+        return uri.charAt(uri.length() - 1) == '/' ? uri : uri + "/";
+    }
+
+    private static OkHttpClient createOkHttpClient(String userAgent) {
+        return new OkHttpClient.Builder()
+                .addInterceptor(UserAgentInterceptor.of(userAgent))
+                .connectionPool(new ConnectionPool(100, 10, TimeUnit.MINUTES))
+                .build();
+    }
+
+    public static <T> T create(Class<T> clazz, String userAgent, String uri,
+            Converter.Factory... specialPurposeConverters) {
+        Retrofit.Builder retrofit = new Retrofit.Builder()
+                .baseUrl(trailingSlash(uri))
+                .client(createOkHttpClient(userAgent));
+        Stream.of(specialPurposeConverters).forEach(retrofit::addConverterFactory);
+        retrofit.addConverterFactory(JacksonConverterFactory.create(ObjectMappers.newObjectMapper()));
+        return retrofit.build().create(clazz);
+    }
+
+}

--- a/extras/slack-clients/src/main/java/com/palantir/roboslack/clients/UserAgentInterceptor.java
+++ b/extras/slack-clients/src/main/java/com/palantir/roboslack/clients/UserAgentInterceptor.java
@@ -21,9 +21,13 @@ import static com.google.common.base.Preconditions.checkArgument;
 import java.io.IOException;
 import java.util.regex.Pattern;
 import okhttp3.Interceptor;
-import okhttp3.Request;
 import okhttp3.Response;
 
+/**
+ * Intercepts requests, then injects and validates the user agent string.
+ *
+ * @since 1.0.0
+ */
 public final class UserAgentInterceptor implements Interceptor {
 
     private static final Pattern VALID_USER_AGENT = Pattern.compile("[A-Za-z0-9()\\-#;/.,_\\s]+");
@@ -41,11 +45,9 @@ public final class UserAgentInterceptor implements Interceptor {
 
     @Override
     public Response intercept(Chain chain) throws IOException {
-        Request originalRequest = chain.request();
-        Request requestWithUserAgent = originalRequest.newBuilder()
+        return chain.proceed(chain.request().newBuilder()
                 .header("User-Agent", userAgent)
-                .build();
-        return chain.proceed(requestWithUserAgent);
+                .build());
     }
 
 }

--- a/extras/slack-clients/src/main/java/com/palantir/roboslack/clients/UserAgentInterceptor.java
+++ b/extras/slack-clients/src/main/java/com/palantir/roboslack/clients/UserAgentInterceptor.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.roboslack.clients;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public final class UserAgentInterceptor implements Interceptor {
+
+    private static final Pattern VALID_USER_AGENT = Pattern.compile("[A-Za-z0-9()\\-#;/.,_\\s]+");
+    private final String userAgent;
+
+    private UserAgentInterceptor(String userAgent) {
+        checkArgument(VALID_USER_AGENT.matcher(userAgent).matches(),
+                "User Agent must match pattern '%s': %s", VALID_USER_AGENT, userAgent);
+        this.userAgent = userAgent;
+    }
+
+    public static UserAgentInterceptor of(String userAgent) {
+        return new UserAgentInterceptor(userAgent);
+    }
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        Request originalRequest = chain.request();
+        Request requestWithUserAgent = originalRequest.newBuilder()
+                .header("User-Agent", userAgent)
+                .build();
+        return chain.proceed(requestWithUserAgent);
+    }
+
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,10 @@
 # Project Dependencies
 guavaVersion = 22.0
-httpRemotingVersion = 2.5.1
+retrofitVersion = 2.3.0
 immutablesVersion = 2.5.3
 jacksonVersion = 2.8.8
 jaxRsVersion = 2.0.1
 mockitoVersion = 1.10.19
-retrofitVersion = 2.3.0
 
 # Build System
 baselineVersion = 0.14.0
@@ -16,6 +15,7 @@ nebulaPublishingPluginVersion = 5.1.0
 bintrayPluginVersion = 1.7.3
 
 # Testing
+awaitilityVersion = 3.0.0
 hamcrestVersion = 1.3
-junitPlatformVersion = 1.0.0-M4
-junitJupiterVersion = 5.0.0-M4
+junitPlatformVersion = 1.0.0-M5
+junitJupiterVersion = 5.0.0-M5

--- a/roboslack-api/src/main/java/com/palantir/roboslack/api/MessageRequest.java
+++ b/roboslack-api/src/main/java/com/palantir/roboslack/api/MessageRequest.java
@@ -192,6 +192,7 @@ public abstract class MessageRequest {
         Builder iconUrl(URL iconUrl);
         Builder username(String username);
         Builder channel(String channel);
+        Builder from(MessageRequest messageRequest);
         MessageRequest build();
     }
 

--- a/roboslack-api/src/main/java/com/palantir/roboslack/api/markdown/SlackMarkdown.java
+++ b/roboslack-api/src/main/java/com/palantir/roboslack/api/markdown/SlackMarkdown.java
@@ -66,7 +66,7 @@ public final class SlackMarkdown {
     public static final ValueDecorator<String> EMOJI = StringDecorator.of(EMOJI_DECORATION);
     public static final ValueDecorator<String> PREFORMAT = StringDecorator.of(PREFORMAT_DECORATION);
     public static final ValueDecorator<String> PREFORMAT_MULTILINE = StringDecorator.of(
-            PREFORMAT_MULTILINE_DECORATION + NEWLINE_SEPARATOR, PREFORMAT_MULTILINE_DECORATION);
+            PREFORMAT_MULTILINE_DECORATION + NEWLINE_SEPARATOR, NEWLINE_SEPARATOR + PREFORMAT_MULTILINE_DECORATION);
     public static final ValueDecorator<String> MENTION_USER = StringDecorator.ofPrefix(MENTION_USER_PREFIX);
     public static final ValueDecorator<String> MENTION_CHANNEL = StringDecorator.ofPrefix(MENTION_CHANNEL_PREFIX);
     public static final ValueDecorator<String> QUOTE = StringDecorator.of(NEWLINE_SEPARATOR + QUOTE_PREFIX,

--- a/roboslack-api/src/test/java/com/palantir/roboslack/api/MessageRequestTests.java
+++ b/roboslack-api/src/test/java/com/palantir/roboslack/api/MessageRequestTests.java
@@ -35,12 +35,11 @@ import com.palantir.roboslack.api.testing.ResourcesReader;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ContainerExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
-import org.junit.jupiter.params.provider.ObjectArrayArguments;
 
 class MessageRequestTests {
 
@@ -113,8 +112,8 @@ class MessageRequestTests {
     static class SerializedMessageRequestsProvider implements ArgumentsProvider {
 
         @Override
-        public Stream<? extends Arguments> arguments(ContainerExtensionContext context) throws Exception {
-            return ResourcesReader.readJson(RESOURCES_DIRECTORY).map(ObjectArrayArguments::create);
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+            return ResourcesReader.readJson(RESOURCES_DIRECTORY).map(Arguments::of);
         }
 
     }

--- a/roboslack-api/src/test/java/com/palantir/roboslack/api/attachments/AttachmentTests.java
+++ b/roboslack-api/src/test/java/com/palantir/roboslack/api/attachments/AttachmentTests.java
@@ -99,8 +99,7 @@ public final class AttachmentTests {
 
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
-            return ResourcesReader.readJson(RESOURCES_DIRECTORY)
-                    .map(Arguments::of);
+            return ResourcesReader.readJson(RESOURCES_DIRECTORY).map(Arguments::of);
         }
 
     }

--- a/roboslack-api/src/test/java/com/palantir/roboslack/api/attachments/AttachmentTests.java
+++ b/roboslack-api/src/test/java/com/palantir/roboslack/api/attachments/AttachmentTests.java
@@ -35,14 +35,13 @@ import com.palantir.roboslack.api.testing.ResourcesReader;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ContainerExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ObjectArrayArguments;
 
 public final class AttachmentTests {
 
@@ -81,7 +80,7 @@ public final class AttachmentTests {
     }
 
     @ParameterizedTest
-    @MethodSource(names = "invalidConstructors")
+    @MethodSource(value = "invalidConstructors")
     void testConstructionConstraints(Executable executable) {
         Throwable thrown = assertThrows(IllegalArgumentException.class, executable);
         assertThat(thrown.getMessage(), either(containsString("cannot be null or empty"))
@@ -99,9 +98,9 @@ public final class AttachmentTests {
     static class SerializedAttachmentsProvider implements ArgumentsProvider {
 
         @Override
-        public Stream<? extends Arguments> arguments(ContainerExtensionContext context) throws Exception {
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
             return ResourcesReader.readJson(RESOURCES_DIRECTORY)
-                    .map(ObjectArrayArguments::create);
+                    .map(Arguments::of);
         }
 
     }

--- a/roboslack-api/src/test/java/com/palantir/roboslack/api/attachments/components/AuthorTests.java
+++ b/roboslack-api/src/test/java/com/palantir/roboslack/api/attachments/components/AuthorTests.java
@@ -27,14 +27,13 @@ import com.palantir.roboslack.api.testing.MoreAssertions;
 import com.palantir.roboslack.api.testing.ResourcesReader;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.extension.ContainerExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ObjectArrayArguments;
 
 public final class AuthorTests {
 
@@ -55,7 +54,7 @@ public final class AuthorTests {
     }
 
     @ParameterizedTest
-    @MethodSource(names = "invalidMarkdownConstructors")
+    @MethodSource(value = "invalidMarkdownConstructors")
     void testDoesNotContainMarkdown(Executable executable) {
         Throwable thrown = assertThrows(IllegalArgumentException.class, executable);
         assertThat(thrown.getMessage(), containsString("cannot contain markdown"));
@@ -72,9 +71,8 @@ public final class AuthorTests {
     static class SerializedAuthorsProvider implements ArgumentsProvider {
 
         @Override
-        public Stream<? extends Arguments> arguments(ContainerExtensionContext context) throws Exception {
-            return ResourcesReader.readJson(RESOURCES_DIRECTORY)
-                    .map(ObjectArrayArguments::create);
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+            return ResourcesReader.readJson(RESOURCES_DIRECTORY).map(Arguments::of);
         }
 
     }

--- a/roboslack-api/src/test/java/com/palantir/roboslack/api/attachments/components/ColorTests.java
+++ b/roboslack-api/src/test/java/com/palantir/roboslack/api/attachments/components/ColorTests.java
@@ -33,13 +33,12 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
-import org.junit.jupiter.api.extension.ContainerExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.junit.jupiter.params.provider.ObjectArrayArguments;
 import org.junit.jupiter.params.provider.ValueSource;
 
 public final class ColorTests {
@@ -111,9 +110,8 @@ public final class ColorTests {
     static class SerializedColorsProvider implements ArgumentsProvider {
 
         @Override
-        public Stream<? extends Arguments> arguments(ContainerExtensionContext context) throws Exception {
-            return ResourcesReader.readJson(RESOURCES_DIRECTORY)
-                    .map(ObjectArrayArguments::create);
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+            return ResourcesReader.readJson(RESOURCES_DIRECTORY).map(Arguments::of);
         }
 
     }

--- a/roboslack-api/src/test/java/com/palantir/roboslack/api/attachments/components/FieldTests.java
+++ b/roboslack-api/src/test/java/com/palantir/roboslack/api/attachments/components/FieldTests.java
@@ -27,14 +27,13 @@ import com.google.common.base.Strings;
 import com.palantir.roboslack.api.testing.MoreAssertions;
 import com.palantir.roboslack.api.testing.ResourcesReader;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.extension.ContainerExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ObjectArrayArguments;
 
 public final class FieldTests {
 
@@ -64,7 +63,7 @@ public final class FieldTests {
     }
 
     @ParameterizedTest
-    @MethodSource(names = "invalidMarkdownConstructors")
+    @MethodSource(value = "invalidMarkdownConstructors")
     void testTitleCannotContainMarkdown(Executable executable) {
         Throwable thrown = assertThrows(IllegalArgumentException.class, executable);
         assertThat(thrown.getMessage(), containsString("cannot contain markdown"));
@@ -73,9 +72,10 @@ public final class FieldTests {
     static class SerializedFieldsProvider implements ArgumentsProvider {
 
         @Override
-        public Stream<? extends Arguments> arguments(ContainerExtensionContext context) throws Exception {
-            return ResourcesReader.readJson(RESOURCES_DIRECTORY).map(ObjectArrayArguments::create);
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+            return ResourcesReader.readJson(RESOURCES_DIRECTORY).map(Arguments::of);
         }
+
     }
 
 }

--- a/roboslack-api/src/test/java/com/palantir/roboslack/api/attachments/components/FooterTests.java
+++ b/roboslack-api/src/test/java/com/palantir/roboslack/api/attachments/components/FooterTests.java
@@ -28,14 +28,13 @@ import com.palantir.roboslack.api.testing.ResourcesReader;
 import java.util.Random;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ContainerExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ObjectArrayArguments;
 
 public final class FooterTests {
 
@@ -65,7 +64,7 @@ public final class FooterTests {
     }
 
     @ParameterizedTest
-    @MethodSource(names = "invalidMarkdownConstructors")
+    @MethodSource(value = "invalidMarkdownConstructors")
     void testDoesNotContainMarkdown(Executable executable) {
         Throwable thrown = assertThrows(IllegalArgumentException.class, executable);
         assertThat(thrown.getMessage(), containsString("cannot contain markdown"));
@@ -90,9 +89,8 @@ public final class FooterTests {
     static class SerializedFootersProvider implements ArgumentsProvider {
 
         @Override
-        public Stream<? extends Arguments> arguments(ContainerExtensionContext context) throws Exception {
-            return ResourcesReader.readJson(RESOURCES_DIRECTORY)
-                    .map(ObjectArrayArguments::create);
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+            return ResourcesReader.readJson(RESOURCES_DIRECTORY).map(Arguments::of);
         }
 
     }

--- a/roboslack-api/src/test/java/com/palantir/roboslack/api/attachments/components/TitleTests.java
+++ b/roboslack-api/src/test/java/com/palantir/roboslack/api/attachments/components/TitleTests.java
@@ -27,14 +27,13 @@ import com.google.common.base.Strings;
 import com.palantir.roboslack.api.testing.MoreAssertions;
 import com.palantir.roboslack.api.testing.ResourcesReader;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.extension.ContainerExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ObjectArrayArguments;
 
 public final class TitleTests {
 
@@ -55,7 +54,7 @@ public final class TitleTests {
     }
 
     @ParameterizedTest
-    @MethodSource(names = "invalidConstructors")
+    @MethodSource(value = "invalidConstructors")
     void testConstructionConstraints(Executable executable) {
         Throwable thrown = assertThrows(IllegalArgumentException.class, executable);
         assertThat(thrown.getMessage(),
@@ -74,10 +73,10 @@ public final class TitleTests {
     static class SerializedTitlesProvider implements ArgumentsProvider {
 
         @Override
-        public Stream<? extends Arguments> arguments(ContainerExtensionContext context) throws Exception {
-            return ResourcesReader.readJson(RESOURCES_DIRECTORY)
-                    .map(ObjectArrayArguments::create);
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+            return ResourcesReader.readJson(RESOURCES_DIRECTORY).map(Arguments::of);
         }
+
     }
 
 }

--- a/roboslack-api/src/test/java/com/palantir/roboslack/api/markdown/LinkDecoratorTests.java
+++ b/roboslack-api/src/test/java/com/palantir/roboslack/api/markdown/LinkDecoratorTests.java
@@ -45,13 +45,13 @@ class LinkDecoratorTests {
     }
 
     @ParameterizedTest
-    @MethodSource(names = "illegalStateConstructors")
+    @MethodSource(value = "illegalStateConstructors")
     void testIllegalStateConstructors(Executable executable) {
         assertThrows(IllegalStateException.class, executable);
     }
 
     @ParameterizedTest
-    @MethodSource(names = "illegalArgumentConstructors")
+    @MethodSource(value = "illegalArgumentConstructors")
     void testIllegalArgumentConstruction(Executable executable) {
         Throwable thrown = assertThrows(IllegalArgumentException.class, executable);
         assertThat(thrown.getMessage(), containsString("present and valid"));

--- a/roboslack-api/src/test/java/com/palantir/roboslack/api/markdown/StringDecoratorTests.java
+++ b/roboslack-api/src/test/java/com/palantir/roboslack/api/markdown/StringDecoratorTests.java
@@ -66,20 +66,20 @@ class StringDecoratorTests {
     }
 
     @ParameterizedTest
-    @MethodSource(names = "nullPointerExceptionConstructors")
+    @MethodSource(value = "nullPointerExceptionConstructors")
     void testNullConstruction(Executable executable) {
         assertThrows(NullPointerException.class, executable);
     }
 
     @ParameterizedTest
-    @MethodSource(names = "illegalArgumentConstructors")
+    @MethodSource(value = "illegalArgumentConstructors")
     void testInvalidConstruction(Executable executable) {
         Throwable thrown = assertThrows(IllegalArgumentException.class, executable);
         assertThat(thrown.getMessage(), containsString("present and valid"));
     }
 
     @ParameterizedTest
-    @MethodSource(names = "validDecorators")
+    @MethodSource(value = "validDecorators")
     void testDecorate(StringDecorator decorator) {
         String decorated = decorator.decorate(EXAMPLE_INPUT_STRING);
         assertThat(decorated, is(not(equalTo(EXAMPLE_INPUT_STRING))));

--- a/roboslack-api/src/test/java/com/palantir/roboslack/api/testing/MoreAssertions.java
+++ b/roboslack-api/src/test/java/com/palantir/roboslack/api/testing/MoreAssertions.java
@@ -20,20 +20,24 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.palantir.roboslack.jackson.ObjectMappers;
 import java.io.IOException;
 import java.util.function.Consumer;
 
 public final class MoreAssertions {
+
+    private static final ObjectMapper OBJECT_MAPPER = ObjectMappers.newObjectMapper();
 
     private MoreAssertions() {}
 
     public static <T> void assertSerializable(JsonNode serialized, Class<T> clazz, Consumer<T> assertion) {
         try {
             // First try deserializing
-            T instance = ObjectMappers.DEFAULT.readValue(ObjectMappers.DEFAULT.writeValueAsString(serialized), clazz);
+            T instance = OBJECT_MAPPER.readValue(OBJECT_MAPPER.writeValueAsString(serialized), clazz);
             assertion.accept(instance);
             // Then reserializing and comparing
-            String reserialized = ObjectMappers.DEFAULT.writeValueAsString(instance);
+            String reserialized = OBJECT_MAPPER.writeValueAsString(instance);
             assertEquals(serialized.toString(), reserialized,
                     String.format("Serialized input '%s' does not match reserialized string: '%s'",
                             serialized.toString(), reserialized));

--- a/roboslack-api/src/test/java/com/palantir/roboslack/api/testing/ResourcesReader.java
+++ b/roboslack-api/src/test/java/com/palantir/roboslack/api/testing/ResourcesReader.java
@@ -20,15 +20,19 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Joiner;
 import com.google.common.io.Files;
 import com.google.common.io.Resources;
+import com.palantir.roboslack.jackson.ObjectMappers;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 
 public final class ResourcesReader {
+
+    private static final ObjectMapper OBJECT_MAPPER = ObjectMappers.newObjectMapper();
 
     private ResourcesReader() {}
 
@@ -51,7 +55,7 @@ public final class ResourcesReader {
 
     private static JsonNode readJson(File file) {
         try {
-            return ObjectMappers.DEFAULT.readTree(readString(file));
+            return OBJECT_MAPPER.readTree(readString(file));
         } catch (IOException e) {
             throw new IllegalArgumentException(e.getMessage(), e);
         }

--- a/roboslack-webhook-api/src/main/java/com/palantir/roboslack/webhook/api/SlackWebHook.java
+++ b/roboslack-webhook-api/src/main/java/com/palantir/roboslack/webhook/api/SlackWebHook.java
@@ -17,10 +17,10 @@
 package com.palantir.roboslack.webhook.api;
 
 import com.palantir.roboslack.api.MessageRequest;
+import com.palantir.roboslack.webhook.api.model.response.ResponseCode;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.POST;
@@ -37,7 +37,7 @@ import retrofit2.http.Path;
 public interface SlackWebHook {
 
     @POST("{token_t_part}/{token_b_part}/{token_x_part}")
-    Call<ResponseBody> sendMessage(
+    Call<ResponseCode> sendMessage(
             @Path("token_t_part") String tokenTPart,
             @Path("token_b_part") String tokenBPart,
             @Path("token_x_part") String tokenXPart,

--- a/roboslack-webhook/build.gradle
+++ b/roboslack-webhook/build.gradle
@@ -20,13 +20,13 @@ apply from: "${rootDir}/gradle/immutables.gradle"
 apply from: "${rootDir}/gradle/publish.gradle"
 
 dependencies {
+    compile project(':extras:slack-clients')
+
     compile project(':roboslack-webhook-api')
 
     compile "com.google.guava:guava:${guavaVersion}"
 
-    // Retrofit for REST client specs
-    compile "com.palantir.remoting2:retrofit2-clients:${httpRemotingVersion}"
-
+    testCompile "org.awaitility:awaitility:${awaitilityVersion}"
     testCompile "org.hamcrest:hamcrest-all:${hamcrestVersion}"
     testCompile "org.mockito:mockito-core:${mockitoVersion}"
 }

--- a/roboslack-webhook/src/main/java/com/palantir/roboslack/webhook/ResponseCodeConverter.java
+++ b/roboslack-webhook/src/main/java/com/palantir/roboslack/webhook/ResponseCodeConverter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.roboslack.webhook;
+
+import com.palantir.roboslack.webhook.api.model.response.ResponseCode;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import okhttp3.ResponseBody;
+import retrofit2.Converter;
+import retrofit2.Retrofit;
+
+public final class ResponseCodeConverter implements Converter<ResponseBody, ResponseCode> {
+
+    @Override
+    public ResponseCode convert(ResponseBody value) throws IOException {
+        return ResponseCode.of(value.string());
+    }
+
+    public static Converter.Factory factory() {
+        return new Converter.Factory() {
+            @Override
+            public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations,
+                    Retrofit retrofit) {
+                return new ResponseCodeConverter();
+            }
+        };
+    }
+
+}

--- a/roboslack-webhook/src/test/java/com/palantir/roboslack/webhook/EnrichTestMessageRequest.java
+++ b/roboslack-webhook/src/test/java/com/palantir/roboslack/webhook/EnrichTestMessageRequest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.roboslack.webhook;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.palantir.roboslack.api.MessageRequest;
+import com.palantir.roboslack.api.attachments.Attachment;
+import java.util.function.BiFunction;
+import org.junit.jupiter.api.TestInfo;
+
+final class EnrichTestMessageRequest implements BiFunction<MessageRequest, TestInfo, MessageRequest> {
+
+    private EnrichTestMessageRequest() {}
+
+    public static EnrichTestMessageRequest get() {
+        return new EnrichTestMessageRequest();
+    }
+
+    @Override
+    public MessageRequest apply(MessageRequest messageRequest, TestInfo testInfo) {
+        checkArgument(testInfo.getTestClass().isPresent());
+        checkArgument(testInfo.getTestMethod().isPresent());
+        String methodName = testInfo.getTestMethod().get().getName();
+        String className = testInfo.getTestClass().get().getSimpleName();
+        String basicSummary = String.format("Called from %s within %s",
+                methodName,
+                className);
+        return MessageRequest.builder()
+                .from(messageRequest)
+                .addAttachments(Attachment.builder()
+                        .fallback(basicSummary)
+                        .text(basicSummary)
+                        .build())
+                .build();
+    }
+
+}

--- a/roboslack-webhook/src/test/java/com/palantir/roboslack/webhook/SlackWebHookServiceTests.java
+++ b/roboslack-webhook/src/test/java/com/palantir/roboslack/webhook/SlackWebHookServiceTests.java
@@ -69,7 +69,7 @@ class SlackWebHookServiceTests {
     @ArgumentsSource(MessageRequestProvider.class)
     void testSendMessage(MessageRequest messageRequest, TestInfo testInfo) {
         assertThat(SlackWebHookService.with(assumingEnvironmentWebHookToken())
-                        .sendMessage(EnrichTestMessageRequest.get().apply(messageRequest, testInfo)),
+                        .sendMessageAsync(EnrichTestMessageRequest.get().apply(messageRequest, testInfo)),
                 is(equalTo(ResponseCode.OK)));
     }
 
@@ -78,7 +78,7 @@ class SlackWebHookServiceTests {
     void testSendMessageAsync(MessageRequest messageRequest, TestInfo testInfo) {
         AtomicBoolean submitted = new AtomicBoolean(false);
         SlackWebHookService.with(assumingEnvironmentWebHookToken())
-                .sendMessage(EnrichTestMessageRequest.get().apply(messageRequest, testInfo),
+                .sendMessageAsync(EnrichTestMessageRequest.get().apply(messageRequest, testInfo),
                         new Callback<ResponseCode>() {
                             @Override
                             @ParametersAreNonnullByDefault

--- a/roboslack-webhook/src/test/java/com/palantir/roboslack/webhook/SlackWebHookServiceTests.java
+++ b/roboslack-webhook/src/test/java/com/palantir/roboslack/webhook/SlackWebHookServiceTests.java
@@ -20,6 +20,8 @@ package com.palantir.roboslack.webhook;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.google.common.collect.ImmutableList;
@@ -37,13 +39,20 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.extension.ContainerExtensionContext;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
-import org.junit.jupiter.params.provider.ObjectArrayArguments;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 class SlackWebHookServiceTests {
 
@@ -58,9 +67,36 @@ class SlackWebHookServiceTests {
 
     @ParameterizedTest
     @ArgumentsSource(MessageRequestProvider.class)
-    void testSendMessage(MessageRequest messageRequest) {
+    void testSendMessage(MessageRequest messageRequest, TestInfo testInfo) {
         assertThat(SlackWebHookService.with(assumingEnvironmentWebHookToken())
-                .sendMessage(messageRequest), is(equalTo(ResponseCode.OK)));
+                        .sendMessage(EnrichTestMessageRequest.get().apply(messageRequest, testInfo)),
+                is(equalTo(ResponseCode.OK)));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(MessageRequestProvider.class)
+    void testSendMessageAsync(MessageRequest messageRequest, TestInfo testInfo) {
+        AtomicBoolean submitted = new AtomicBoolean(false);
+        SlackWebHookService.with(assumingEnvironmentWebHookToken())
+                .sendMessage(EnrichTestMessageRequest.get().apply(messageRequest, testInfo),
+                        new Callback<ResponseCode>() {
+                            @Override
+                            @ParametersAreNonnullByDefault
+                            public void onResponse(Call<ResponseCode> call, Response<ResponseCode> response) {
+                                submitted.set(true);
+                                assertTrue(call.isExecuted());
+                                assertThat(response.body(), is(equalTo(ResponseCode.OK)));
+                            }
+
+                            @Override
+                            @ParametersAreNonnullByDefault
+                            public void onFailure(Call<ResponseCode> call, Throwable throwable) {
+                                submitted.set(true);
+                                assertTrue(call.isExecuted());
+                                fail(throwable);
+                            }
+                        });
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).untilTrue(submitted);
     }
 
     static class MessageRequestProvider implements ArgumentsProvider {
@@ -152,15 +188,14 @@ class SlackWebHookServiceTests {
         }
 
         @Override
-        public Stream<? extends Arguments> arguments(ContainerExtensionContext context) throws Exception {
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
             return Stream.of(
                     MESSAGE_SIMPLE,
                     MESSAGE_WITH_ATTACHMENT_FOOTER,
                     MESSAGE_WITH_ATTACHMENTS,
                     MESSAGE_COMPLEX
-            ).map(ObjectArrayArguments::create);
+            ).map(Arguments::of);
         }
-
     }
 
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,8 @@
 rootProject.name = 'roboslack'
 
+include 'extras:jackson-support'
+include 'extras:slack-clients'
+
 include 'roboslack-api'
 include 'roboslack-webhook-api'
 include 'roboslack-webhook'


### PR DESCRIPTION
A bit larger than I would have hoped, but we needed a good way to handle `ResponseCode`s natively in order to add async support.

Overview:
- Added support for async sending
- bumped junit5 version to M5
- switched out http-remoting for embedded retrofit impl for native response code conversion



RFC: @elektron9 