### PR TITLE
Removed Markdown checks on plaintext fields 

### DIFF
--- a/roboslack-api/src/main/java/com/palantir/roboslack/api/attachments/Attachment.java
+++ b/roboslack-api/src/main/java/com/palantir/roboslack/api/attachments/Attachment.java
@@ -72,7 +72,6 @@ public abstract class Attachment {
     @Value.Check
     protected final void check() {
         checkArgument(!Strings.isNullOrEmpty(fallback()), "Attachment fallback message cannot be null or empty");
-        MorePreconditions.checkDoesNotContainMarkdown(FALLBACK_FIELD, fallback());
     }
 
     /**
@@ -88,7 +87,8 @@ public abstract class Attachment {
 
     /**
      * The plaintext summary of this {@link Attachment}. This text is used in clients that don't show formatted text
-     * (eg. IRC, mobile notifications) and should not contain any markup.
+     * (eg. IRC, mobile notifications) and should not contain any Markdown. Please note that you can pass Markdown
+     * characters in this field, but Slack will print them as literal plaintext.
      *
      * @return the {@code fallback} text
      */

--- a/roboslack-api/src/main/java/com/palantir/roboslack/api/attachments/Attachment.java
+++ b/roboslack-api/src/main/java/com/palantir/roboslack/api/attachments/Attachment.java
@@ -86,9 +86,9 @@ public abstract class Attachment {
     }
 
     /**
-     * The plaintext summary of this {@link Attachment}. This text is used in clients that don't show formatted text
-     * (eg. IRC, mobile notifications) and should not contain any Markdown. Please note that you can pass Markdown
-     * characters in this field, but Slack will print them as literal plaintext.
+     * The plaintext summary of this {@link Attachment} used in clients that don't display formatted text. <br/>
+     * <b>Note:</b> If this text contains any {@link com.palantir.roboslack.api.markdown.SlackMarkdown} special
+     * characters, they will be treated as literal plaintext characters when rendered in any Slack client.
      *
      * @return the {@code fallback} text
      */

--- a/roboslack-api/src/main/java/com/palantir/roboslack/api/attachments/components/Author.java
+++ b/roboslack-api/src/main/java/com/palantir/roboslack/api/attachments/components/Author.java
@@ -19,7 +19,6 @@ package com.palantir.roboslack.api.attachments.components;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.palantir.roboslack.utils.MorePreconditions;
 import java.net.URL;
 import java.util.Optional;
 import org.immutables.value.Value;
@@ -50,18 +49,12 @@ public abstract class Author {
 
     @Value.Check
     protected final void check() {
-        MorePreconditions.checkDoesNotContainMarkdown(NAME_FIELD, name());
-    }
 
-    public interface Builder {
-        Builder name(String name);
-        Builder link(URL link);
-        Builder icon(URL icon);
-        Author build();
     }
 
     /**
-     * Small text used to display this {@link Author}'s {@code name}.
+     * Small text used to display this {@link Author}'s {@code name}. Please note that you can pass Markdown
+     * characters in this field, but Slack will print them as literal plaintext.
      *
      * @return the author's name
      */
@@ -71,7 +64,7 @@ public abstract class Author {
     /**
      * A valid {@link URL} that will be applied to the {@link Author#name()}.
      *
-     * @return an {@link Optional} containing the link applied to the {@code name} get the {@link Author}
+     * @return an {@link Optional} containing the link applied to the {@code name} for the {@link Author}
      */
     @JsonProperty(LINK_FIELD)
     public abstract Optional<URL> link();
@@ -80,10 +73,20 @@ public abstract class Author {
      * A valid {@link URL} that referencing a small 16x16px image that is displayed the left of the {@link
      * Author#name()}.
      *
-     * @return an {@link Optional} containing the link to the {@code icon} get the {@link Author}
+     * @return an {@link Optional} containing the link to the {@code icon} for the {@link Author}
      */
     @JsonProperty(ICON_FIELD)
     public abstract Optional<URL> icon();
+
+    public interface Builder {
+        Builder name(String name);
+
+        Builder link(URL link);
+
+        Builder icon(URL icon);
+
+        Author build();
+    }
 
 }
 

--- a/roboslack-api/src/main/java/com/palantir/roboslack/api/attachments/components/Author.java
+++ b/roboslack-api/src/main/java/com/palantir/roboslack/api/attachments/components/Author.java
@@ -53,8 +53,9 @@ public abstract class Author {
     }
 
     /**
-     * Small text used to display this {@link Author}'s {@code name}. Please note that you can pass Markdown
-     * characters in this field, but Slack will print them as literal plaintext.
+     * Small text used to display this {@link Author}'s {@code name}. <br/>
+     * <b>Note:</b> If this text contains any {@link com.palantir.roboslack.api.markdown.SlackMarkdown} special
+     * characters, they will be treated as literal plaintext characters when rendered in any Slack client.
      *
      * @return the author's name
      */

--- a/roboslack-api/src/main/java/com/palantir/roboslack/api/attachments/components/Field.java
+++ b/roboslack-api/src/main/java/com/palantir/roboslack/api/attachments/components/Field.java
@@ -19,7 +19,6 @@ package com.palantir.roboslack.api.attachments.components;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.palantir.roboslack.utils.MorePreconditions;
 import org.immutables.value.Value;
 
 /**
@@ -59,18 +58,12 @@ public abstract class Field {
 
     @Value.Check
     protected final void check() {
-        MorePreconditions.checkDoesNotContainMarkdown(TITLE_FIELD, title());
-    }
 
-    public interface Builder {
-        Builder title(String title);
-        Builder value(String value);
-        Builder isShort(boolean isShort);
-        Field build();
     }
 
     /**
-     * The bold heading above the {@link Field#value()} text.
+     * The bold heading above the {@link Field#value()} text. Please note that you can pass Markdown
+     * characters in this field, but Slack will print them as literal plaintext.
      *
      * @return the title
      */
@@ -84,5 +77,15 @@ public abstract class Field {
      */
     @JsonProperty(VALUE_FIELD)
     public abstract String value();
+
+    public interface Builder {
+        Builder title(String title);
+
+        Builder value(String value);
+
+        Builder isShort(boolean isShort);
+
+        Field build();
+    }
 
 }

--- a/roboslack-api/src/main/java/com/palantir/roboslack/api/attachments/components/Field.java
+++ b/roboslack-api/src/main/java/com/palantir/roboslack/api/attachments/components/Field.java
@@ -65,6 +65,7 @@ public abstract class Field {
      * The bold heading above the {@link Field#value()} text. <br/>
      * <b>Note:</b> If this text contains any {@link com.palantir.roboslack.api.markdown.SlackMarkdown} special
      * characters, they will be treated as literal plaintext characters when rendered in any Slack client.
+     * Note that Slack does allow this field to contain emoji, but no other Markdown.
      *
      * @return the title
      */

--- a/roboslack-api/src/main/java/com/palantir/roboslack/api/attachments/components/Field.java
+++ b/roboslack-api/src/main/java/com/palantir/roboslack/api/attachments/components/Field.java
@@ -62,8 +62,9 @@ public abstract class Field {
     }
 
     /**
-     * The bold heading above the {@link Field#value()} text. Please note that you can pass Markdown
-     * characters in this field, but Slack will print them as literal plaintext.
+     * The bold heading above the {@link Field#value()} text. <br/>
+     * <b>Note:</b> If this text contains any {@link com.palantir.roboslack.api.markdown.SlackMarkdown} special
+     * characters, they will be treated as literal plaintext characters when rendered in any Slack client.
      *
      * @return the title
      */

--- a/roboslack-api/src/main/java/com/palantir/roboslack/api/attachments/components/Footer.java
+++ b/roboslack-api/src/main/java/com/palantir/roboslack/api/attachments/components/Footer.java
@@ -56,7 +56,6 @@ public abstract class Footer {
 
     @Value.Check
     protected final void check() {
-        MorePreconditions.checkDoesNotContainMarkdown(TEXT_FIELD, text());
         MorePreconditions.checkCharacterLength(TEXT_FIELD, text(), MAX_FOOTER_CHARACTER_LENGTH);
     }
 
@@ -68,7 +67,8 @@ public abstract class Footer {
     }
 
     /**
-     * Text that describes and contextualizes its attachment.
+     * Text that describes and contextualizes its attachment. Please note that you can pass Markdown
+     * characters in this field, but Slack will print them as literal plaintext.
      *
      * @return the text
      */

--- a/roboslack-api/src/main/java/com/palantir/roboslack/api/attachments/components/Footer.java
+++ b/roboslack-api/src/main/java/com/palantir/roboslack/api/attachments/components/Footer.java
@@ -67,8 +67,9 @@ public abstract class Footer {
     }
 
     /**
-     * Text that describes and contextualizes its attachment. Please note that you can pass Markdown
-     * characters in this field, but Slack will print them as literal plaintext.
+     * Text that describes and contextualizes its attachment. <br/>
+     * <b>Note:</b> If this text contains any {@link com.palantir.roboslack.api.markdown.SlackMarkdown} special
+     * characters, they will be treated as literal plaintext characters when rendered in any Slack client.
      *
      * @return the text
      */

--- a/roboslack-api/src/main/java/com/palantir/roboslack/api/attachments/components/Title.java
+++ b/roboslack-api/src/main/java/com/palantir/roboslack/api/attachments/components/Title.java
@@ -54,8 +54,9 @@ public abstract class Title {
     }
 
     /**
-     * The title text displayed at the top of the message attachment. Please note that you can pass Markdown
-     * characters in this field, but Slack will print them as literal plaintext.
+     * The title text displayed at the top of the message attachment. <br/>
+     * <b>Note:</b> If this text contains any {@link com.palantir.roboslack.api.markdown.SlackMarkdown} special
+     * characters, they will be treated as literal plaintext characters when rendered in any Slack client.
      *
      * @return the title text
      */

--- a/roboslack-api/src/main/java/com/palantir/roboslack/api/attachments/components/Title.java
+++ b/roboslack-api/src/main/java/com/palantir/roboslack/api/attachments/components/Title.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Strings;
-import com.palantir.roboslack.utils.MorePreconditions;
 import java.net.URL;
 import java.util.Optional;
 import org.immutables.value.Value;
@@ -51,18 +50,12 @@ public abstract class Title {
 
     @Value.Check
     protected final void check() {
-        MorePreconditions.checkDoesNotContainMarkdown(TEXT_FIELD, text());
         checkArgument(!Strings.isNullOrEmpty(text()), "The title text field cannot be null or empty");
     }
 
-    public interface Builder {
-        Builder text(String text);
-        Builder link(URL link);
-        Title build();
-    }
-
     /**
-     * The title text displayed at the top get the message attachment.
+     * The title text displayed at the top of the message attachment. Please note that you can pass Markdown
+     * characters in this field, but Slack will print them as literal plaintext.
      *
      * @return the title text
      */
@@ -76,5 +69,13 @@ public abstract class Title {
      */
     @JsonProperty(LINK_FIELD)
     public abstract Optional<URL> link();
+
+    public interface Builder {
+        Builder text(String text);
+
+        Builder link(URL link);
+
+        Title build();
+    }
 
 }

--- a/roboslack-api/src/main/java/com/palantir/roboslack/utils/MorePreconditions.java
+++ b/roboslack-api/src/main/java/com/palantir/roboslack/utils/MorePreconditions.java
@@ -50,10 +50,6 @@ public final class MorePreconditions {
                 content.length());
     }
 
-    public static void checkDoesNotContainMarkdown(String fieldName, String content) {
-        checkArgument(!containsMarkdown(content), MARKDOWN_ERROR_FORMAT, fieldName);
-    }
-
     public static void checkHexColor(String value) {
         checkArgument(HEX_COLOR_PATTERN.matcher(value).find(), HEX_COLOR_ERROR_FORMAT, value);
     }

--- a/roboslack-api/src/test/java/com/palantir/roboslack/api/attachments/AttachmentTests.java
+++ b/roboslack-api/src/test/java/com/palantir/roboslack/api/attachments/AttachmentTests.java
@@ -63,8 +63,7 @@ public final class AttachmentTests {
     @SuppressWarnings("unchecked") // Called from reflection
     static Stream<Executable> invalidConstructors() {
         return Stream.of(
-                () -> Attachment.builder().fallback("").build(),
-                () -> Attachment.builder().fallback("_markdown_").build()
+                () -> Attachment.builder().fallback("").build()
         );
     }
 

--- a/roboslack-api/src/test/java/com/palantir/roboslack/api/attachments/components/AuthorTests.java
+++ b/roboslack-api/src/test/java/com/palantir/roboslack/api/attachments/components/AuthorTests.java
@@ -16,10 +16,7 @@
 
 package com.palantir.roboslack.api.attachments.components;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Strings;
@@ -28,12 +25,10 @@ import com.palantir.roboslack.api.testing.ResourcesReader;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
-import org.junit.jupiter.params.provider.MethodSource;
 
 public final class AuthorTests {
 
@@ -43,21 +38,6 @@ public final class AuthorTests {
         assertFalse(Strings.isNullOrEmpty(author.name()));
         author.link().ifPresent(Assertions::assertNotNull);
         author.icon().ifPresent(Assertions::assertNotNull);
-    }
-
-    @SuppressWarnings("unused") // Called from reflection
-    static Stream<Executable> invalidMarkdownConstructors() {
-        return Stream.of(
-                () -> Author.builder().name("*name*").build(),
-                () -> Author.of("-strike-")
-        );
-    }
-
-    @ParameterizedTest
-    @MethodSource(value = "invalidMarkdownConstructors")
-    void testDoesNotContainMarkdown(Executable executable) {
-        Throwable thrown = assertThrows(IllegalArgumentException.class, executable);
-        assertThat(thrown.getMessage(), containsString("cannot contain markdown"));
     }
 
     @ParameterizedTest

--- a/roboslack-api/src/test/java/com/palantir/roboslack/api/attachments/components/FieldTests.java
+++ b/roboslack-api/src/test/java/com/palantir/roboslack/api/attachments/components/FieldTests.java
@@ -17,10 +17,7 @@
 package com.palantir.roboslack.api.attachments.components;
 
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Strings;
@@ -28,12 +25,10 @@ import com.palantir.roboslack.api.testing.MoreAssertions;
 import com.palantir.roboslack.api.testing.ResourcesReader;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
-import org.junit.jupiter.params.provider.MethodSource;
 
 public final class FieldTests {
 
@@ -44,28 +39,12 @@ public final class FieldTests {
         assertFalse(Strings.isNullOrEmpty(field.value()));
     }
 
-    @SuppressWarnings("unused") // Called from reflection
-    static Stream<Executable> invalidMarkdownConstructors() {
-        return Stream.of(
-                () -> Field.of("*title with bold*", "Valid"),
-                () -> Field.builder().title("_Sad Times_")
-                        .value("Hello *failing* test! :smile:").build()
-        );
-    }
-
     @ParameterizedTest
     @ArgumentsSource(SerializedFieldsProvider.class)
     void testSerialization(JsonNode json) {
         MoreAssertions.assertSerializable(json,
                 Field.class,
                 FieldTests::assertValid);
-    }
-
-    @ParameterizedTest
-    @MethodSource(value = "invalidMarkdownConstructors")
-    void testTitleCannotContainMarkdown(Executable executable) {
-        Throwable thrown = assertThrows(IllegalArgumentException.class, executable);
-        assertThat(thrown.getMessage(), containsString("cannot contain markdown"));
     }
 
     static class SerializedFieldsProvider implements ArgumentsProvider {

--- a/roboslack-api/src/test/java/com/palantir/roboslack/api/attachments/components/FooterTests.java
+++ b/roboslack-api/src/test/java/com/palantir/roboslack/api/attachments/components/FooterTests.java
@@ -29,24 +29,14 @@ import java.util.Random;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
-import org.junit.jupiter.params.provider.MethodSource;
 
 public final class FooterTests {
 
     private static final String RESOURCES_DIRECTORY = "parameters/attachments/components/footers";
-
-    @SuppressWarnings("unused") // Called from reflection
-    static Stream<Executable> invalidMarkdownConstructors() {
-        return Stream.of(
-                () -> Footer.of("*footer*"),
-                () -> Footer.builder().text("-footer-").build()
-        );
-    }
 
     private static String generateRandomStringOfSize(int size) {
         return new Random().ints('a', 'z')
@@ -61,13 +51,6 @@ public final class FooterTests {
                 assertFalse(Strings.isNullOrEmpty(icon.getPath())));
         footer.timestamp().ifPresent(timestamp ->
                 assertFalse(Strings.isNullOrEmpty(timestamp.toString())));
-    }
-
-    @ParameterizedTest
-    @MethodSource(value = "invalidMarkdownConstructors")
-    void testDoesNotContainMarkdown(Executable executable) {
-        Throwable thrown = assertThrows(IllegalArgumentException.class, executable);
-        assertThat(thrown.getMessage(), containsString("cannot contain markdown"));
     }
 
     @Test

--- a/roboslack-api/src/test/java/com/palantir/roboslack/api/attachments/components/TitleTests.java
+++ b/roboslack-api/src/test/java/com/palantir/roboslack/api/attachments/components/TitleTests.java
@@ -47,9 +47,7 @@ public final class TitleTests {
     @SuppressWarnings("unused") // Called from reflection
     static Stream<Executable> invalidConstructors() {
         return Stream.of(
-                () -> Title.of(""),
-                () -> Title.of("-strike-"),
-                () -> Title.builder().text("*bold*").build()
+                () -> Title.of("")
         );
     }
 

--- a/roboslack-webhook/src/test/java/com/palantir/roboslack/webhook/SlackWebHookServiceTests.java
+++ b/roboslack-webhook/src/test/java/com/palantir/roboslack/webhook/SlackWebHookServiceTests.java
@@ -118,6 +118,39 @@ class SlackWebHookServiceTests {
                         .build())
                 .build();
 
+        private static final MessageRequest MESSAGE_MARKDOWN_IN_PLAINTEXT_ATTACHMENT_FIELDS = MessageRequest.builder()
+                .username("robo-slack")
+                .iconEmoji(SlackMarkdown.EMOJI.decorate("smile"))
+                .text("Message with Markdown in plaintext Attachment fields")
+                .addAttachments(Attachment.builder()
+                        .fallback(SlackMarkdown.STRIKE.decorate("attachment fallback text"))
+                        .text("some attachment text")
+                        .title(
+                                Title.builder()
+                                .text(SlackMarkdown.PREFORMAT.decorate("preformat markdown"))
+                                .build()
+                        )
+                        .author(
+                                Author.builder()
+                                .name(SlackMarkdown.QUOTE.decorate("quote markdown"))
+                                .build()
+                        )
+                        .addFields(
+                                Field.builder()
+                                        .title(SlackMarkdown.STRIKE.decorate("strikethrough markdown"))
+                                        .value("value")
+                                        .build()
+                        )
+                        .footer(
+                                Footer.builder()
+                                        .text(SlackMarkdown.ITALIC.decorate("italic markdown"))
+                                        .timestamp(LocalDateTime.now()
+                                                .atZone(ZoneId.systemDefault()).toEpochSecond())
+                                        .build()
+                        )
+                        .build())
+                .build();
+
         private static final MessageRequest MESSAGE_MARKDOWN_IN_ATTACHMENT_TEXT = MessageRequest.builder()
                 .username("robo-slack")
                 .iconEmoji(SlackMarkdown.EMOJI.decorate("smile"))
@@ -231,6 +264,7 @@ class SlackWebHookServiceTests {
             return Stream.of(
                     MESSAGE_SIMPLE,
                     MESSAGE_MARKDOWN_IN_ATTACHMENT_PRETEXT,
+                    MESSAGE_MARKDOWN_IN_PLAINTEXT_ATTACHMENT_FIELDS,
                     MESSAGE_MARKDOWN_IN_ATTACHMENT_TEXT,
                     MESSAGE_MARKDOWN_IN_ATTACHMENT_FIELDS,
                     MESSAGE_WITH_ATTACHMENT_FOOTER,


### PR DESCRIPTION
* Removed Markdown checks on plaintext fields.
* Added documentation stating that these fields will be treated as literals by Slack. 
* Added test case around plaintext fields.
* Updated existing test cases for Markdown in fields.

Fixes #19. @dotCipher for PR.